### PR TITLE
Maven publish configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ requests are served before shutdown at least hard. Streamee on the other hand au
 into Akka's coordinated shutdown: it makes sure that during shutdown no more commands are accepted
 and all in-flight commands have been processed.
 
+## Installation
+
+Include streamee in your project by adding the following to your `build.sbt`:
+
+```
+libraryDependencies += "io.moia" %% "streamee" % "3.1.0"
+```
+
+Artifacts are hosted on Maven Central.
+
 ## Usage and API
 
 In order to use Streamee we first have to define domain logic for each process. Streamee requires to
@@ -95,3 +105,23 @@ The `onProcessorSuccess` directive handles the result of offering to the process
 (happiest path) it dispatches the associated result to the inner route via `onSuccess`, if `Dropped`
 (not so happy path) it completes the HTTP request with `ServiceUnavailable` and else (failure case,
 should not happen) completes the HTTP request with `InternalServerError`.
+
+## License
+
+This code is open source software licensed under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
+
+## Publishing
+
+To publish a release to Maven central follow these steps:
+
+1. Create a release via GitHub
+2. Publish artifact to OSS Sonatype stage repository:
+    ```
+    sbt publishSigned
+    ```  
+    Note that your Sonatype credentials needs to be configured on your machine and you need to have access writes to publish artifacts to the group id `io.moia`.
+3. Release artifact to Maven Central with:
+      ```
+      sbt sonatypeRelease
+      ```
+

--- a/build.sbt
+++ b/build.sbt
@@ -104,6 +104,7 @@ lazy val settings =
   commonSettings ++
   scalafmtSettings ++
   dockerSettings ++
+  sonatypeSettings ++
   commandAliases
 
 lazy val commonSettings =
@@ -124,8 +125,7 @@ lazy val commonSettings =
     ),
     Compile / unmanagedSourceDirectories := Seq((Compile / scalaSource).value),
     Test / unmanagedSourceDirectories := Seq((Test / scalaSource).value),
-    testFrameworks += new TestFramework("utest.runner.Framework"),
-    publishTo := Some("MOIA Artifactory" at "https://moiadev.jfrog.io/moiadev/sbt-release-local")
+    testFrameworks += new TestFramework("utest.runner.Framework")
   )
 
 lazy val scalafmtSettings =
@@ -141,6 +141,17 @@ lazy val dockerSettings =
     dockerBaseImage := "openjdk:10.0.2-slim",
     dockerExposedPorts := Seq(80, 8558)
   )
+
+lazy val sonatypeSettings = {
+  import xerial.sbt.Sonatype._
+  Seq(
+    publishTo := sonatypePublishTo.value,
+    sonatypeProfileName := organization.value,
+    publishMavenStyle := true,
+    sonatypeProjectHosting := Some(GitHubHosting("moia-dev", "streamee", "support@moia.io"))
+  )
+}
+
 
 lazy val commandAliases =
   addCommandAlias(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,5 +3,7 @@ addSbtPlugin("com.geirsson"      % "sbt-scalafmt"        % "1.5.1")
 addSbtPlugin("com.typesafe.sbt"  % "sbt-native-packager" % "1.3.6")
 addSbtPlugin("de.heikoseeberger" % "sbt-header"          % "5.0.0")
 addSbtPlugin("io.spray"          % "sbt-revolver"        % "0.9.1")
+addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype"        % "2.3")
+addSbtPlugin("com.jsuereth"      % "sbt-pgp"             % "1.1.1")
 
 libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.25" // Needed by sbt-git


### PR DESCRIPTION
PR adds SBT configuration to publish to Sonatype/Maven Central leveraging `sbt-sonatype` and `sbt-pgp` plugins.

Smoke test of publishing to Sonatype Snapshot repository was successful: https://oss.sonatype.org/service/local/repositories/snapshots/archive/io/moia/streamee_2.12/3.1.0-SNAPSHOT

Publish configuration to MOIA's Artifactory repository has been removed.