### PR TITLE
Hook processors into coordinated shutdown

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -59,13 +59,13 @@ lazy val `streamee-demo` =
 lazy val library =
   new {
     object Version {
-      val akka           = "2.5.23"
-      val akkaHttp       = "10.1.8"
+      val akka           = "2.5.24"
+      val akkaHttp       = "10.1.9"
       val akkaHttpJson   = "1.27.0"
       val akkaLog4j      = "1.6.1"
       val circe          = "0.11.1"
       val disruptor      = "3.4.2"
-      val log4j          = "2.12.0"
+      val log4j          = "2.12.1"
       val log4jApiScala  = "11.0"
       val pureConfig     = "0.11.1"
       val scalaCheck     = "1.14.0"

--- a/streamee/src/main/scala/io/moia/streamee/FrontProcessor.scala
+++ b/streamee/src/main/scala/io/moia/streamee/FrontProcessor.scala
@@ -26,6 +26,7 @@ import akka.stream.{
 }
 import akka.stream.scaladsl.{ Keep, Sink, Source }
 import akka.Done
+import akka.actor.CoordinatedShutdown
 import akka.stream.QueueOfferResult.{ Dropped, Enqueued }
 import org.apache.logging.log4j.scala.Logging
 import scala.concurrent.{ ExecutionContext, Future }
@@ -50,15 +51,29 @@ object FrontProcessor {
       extends Exception(s"QueueOfferResult $cause was not expected!")
 
   /**
-    * See [[FrontProcessor]].
+    * Run a `Source.queue` for pairs of request and [[Respondee]] via the given `process` to a
+    * `Sink` responding to the [[Respondee]].
+    *
+    * When [[FrontProcessor.accept]] is called, the given request is emitted into the process. The
+    * returned `Future` is either completed successfully with the response or failed if the process
+    * back-pressures or does not create the response in time.
+    *
+    * @param process top-level domain logic process from request to response
+    * @param timeout maximum duration for the running process to respond; must be positive!
+    * @param name name, used for logging and exceptions
+    * @param bufferSize optional size of the buffer of the used `MergeHub.source`; defaults to 1; must be positive!
+    * @param phase identifier for a phase of `CoordinatedShutdown`; defaults to "service-requests-done"; must be defined in configufation!
+    * @tparam Req request type
+    * @tparam Res response type
     */
   def apply[Req, Res](
       process: Process[Req, Res, Res],
       timeout: FiniteDuration,
       name: String,
-      bufferSize: Int = 1
+      bufferSize: Int = 1,
+      phase: String = CoordinatedShutdown.PhaseServiceRequestsDone
   )(implicit mat: Materializer, ec: ExecutionContext): FrontProcessor[Req, Res] =
-    new FrontProcessor(process, timeout, name, bufferSize)
+    new FrontProcessor(process, timeout, name, bufferSize, phase)
 }
 
 /**
@@ -69,10 +84,11 @@ object FrontProcessor {
   * returned `Future` is either completed successfully with the response or failed if the process
   * back-pressures or does not create the response in time.
   *
-  * @param process    top-level domain logic process from request to response
-  * @param timeout    maximum duration for the running process to respond; must be positive!
-  * @param name       name, used for logging and exceptions
+  * @param process top-level domain logic process from request to response
+  * @param timeout maximum duration for the running process to respond; must be positive!
+  * @param name name, used for logging and exceptions
   * @param bufferSize optional size of the buffer of the used `MergeHub.source`; defaults to 1; must be positive!
+  * @param phase identifier for a phase of `CoordinatedShutdown`; defaults to "service-requests-done"; must be defined in configufation!
   * @tparam Req request type
   * @tparam Res response type
   */
@@ -80,23 +96,36 @@ final class FrontProcessor[Req, Res] private (
     process: Process[Req, Res, Res],
     timeout: FiniteDuration,
     name: String,
-    bufferSize: Int = 1
+    bufferSize: Int,
+    phase: String
 )(implicit mat: Materializer, ec: ExecutionContext)
     extends Logging {
   import FrontProcessor._
 
-  require(timeout > Duration.Zero, s"timeout for processor $name must be > 0, but was $timeout!")
-  require(bufferSize > 0, s"bufferSize for processor $name must be > 0, but was $bufferSize!")
+  require(
+    timeout > Duration.Zero,
+    s"timeout for processor $name must be > 0, but was $timeout!"
+  )
+  require(
+    bufferSize > 0,
+    s"bufferSize for processor $name must be > 0, but was $bufferSize!"
+  )
 
   private val (queue, _done) =
     Source
       .queue[(Req, Respondee[Res])](bufferSize, OverflowStrategy.dropNew)
       .via(process)
-      .toMat(
-        Sink.foreach { case (response, respondee) => respondee ! Respondee.Response(response) }
-      )(Keep.both)
+      .toMat(Sink.foreach {
+        case (response, respondee) => respondee ! Respondee.Response(response)
+      })(Keep.both)
       .withAttributes(ActorAttributes.supervisionStrategy(resume))
       .run()
+
+  CoordinatedShutdown(toActorMaterializer(mat).system)
+    .addTask(phase, s"shutdown-front-processor-$name") { () =>
+      shutdown()
+      whenDone
+    }
 
   /**
     * Ingest the given request into the process. The returned `Future` is either completed
@@ -105,7 +134,7 @@ final class FrontProcessor[Req, Res] private (
     * in time.
     *
     * @param request request to be accepted
-    * @return `Future` for the response
+    * @return eventual response
     */
   def accept(request: Req): Future[Res] = {
     val (respondee, response) = Respondee.spawn[Res](timeout)
@@ -132,7 +161,7 @@ final class FrontProcessor[Req, Res] private (
     * The returned `Future` is completed when the running process is completed, e.g. via
     * [[shutdown]] or unexpected failure.
     *
-    * @return signal for completion
+    * @return completion signal
     */
   def whenDone: Future[Done] =
     _done

--- a/streamee/src/main/scala/io/moia/streamee/Process.scala
+++ b/streamee/src/main/scala/io/moia/streamee/Process.scala
@@ -22,10 +22,11 @@ import org.apache.logging.log4j.scala.Logging
 object Process extends Logging {
 
   /**
-    * Factory for a [[Process]]. Convenient shortcut for `FlowWithContext[Req, Respondee[Res]]`.
+    * Factory for an empty [[Process]]. Convenient shortcut for `FlowWithContext[Req, Respondee[Res]]`.
     *
     * @tparam Req request type
     * @tparam Res response type
+    * @return empty [[Process]]
     */
   def apply[Req, Res](): Process[Req, Req, Res] =
     FlowWithContext[Req, Respondee[Res]]

--- a/streamee/src/main/scala/io/moia/streamee/package.scala
+++ b/streamee/src/main/scala/io/moia/streamee/package.scala
@@ -17,6 +17,7 @@
 package io.moia
 
 import akka.actor.typed.ActorRef
+import akka.actor.CoordinatedShutdown
 import akka.stream.{ ActorMaterializer, DelayOverflowStrategy, Materializer, SinkRef, ThrottleMode }
 import akka.stream.scaladsl.{ Flow, FlowWithContext, Sink, Source }
 import scala.concurrent.duration.{ Duration, FiniteDuration }
@@ -201,6 +202,9 @@ package object streamee {
         Flow.apply.throttle(elements, per, maximumBurst, mode)
       )
   }
+
+  private[streamee] def coordinatedShutdown(mat: Materializer) =
+    CoordinatedShutdown(toActorMaterializer(mat).system)
 
   private[streamee] def toActorMaterializer(mat: Materializer) =
     mat.asInstanceOf[ActorMaterializer]

--- a/streamee/src/main/scala/io/moia/streamee/package.scala
+++ b/streamee/src/main/scala/io/moia/streamee/package.scala
@@ -17,7 +17,7 @@
 package io.moia
 
 import akka.actor.typed.ActorRef
-import akka.stream.{ DelayOverflowStrategy, Materializer, SinkRef, ThrottleMode }
+import akka.stream.{ ActorMaterializer, DelayOverflowStrategy, Materializer, SinkRef, ThrottleMode }
 import akka.stream.scaladsl.{ Flow, FlowWithContext, Sink, Source }
 import scala.concurrent.duration.{ Duration, FiniteDuration }
 import scala.concurrent.{ Future, Promise }
@@ -29,7 +29,8 @@ package object streamee {
     * propagates a [[Respondee]] for the top-level response. For a top-level process Out == Res. Can
     * be used locally or remotely.
     */
-  type Process[-In, Out, Res] = FlowWithContext[In, Respondee[Res], Out, Respondee[Res], Any]
+  type Process[-In, Out, Res] =
+    FlowWithContext[In, Respondee[Res], Out, Respondee[Res], Any]
 
   /**
     * Convenient shortcut for `ActorRef[Respondee.Response[A]]`.
@@ -66,14 +67,19 @@ package object streamee {
       * @param processSink [[ProcessSink]] to emit into
       * @param timeout maximum duration for the running process to respond; must be positive!
       * @tparam Out2 response type of the given [[ProcessSink]]
+      * @return `Source` emitting responses of the given [[ProcessSink]]
       */
     def into[Out2](processSink: ProcessSink[Out, Out2],
                    timeout: FiniteDuration): Source[Out2, Future[M]] = {
-      require(timeout > Duration.Zero, s"timeout must be > 0, but was $timeout!")
+      require(
+        timeout > Duration.Zero,
+        s"timeout must be > 0, but was $timeout!"
+      )
 
       Source
         .setup { (mat, _) => // We need the `ActorMaterializer` to get its `system`!
-          val parallelism = mat.system.settings.config.getInt("streamee.max-into-parallelism")
+          val parallelism =
+            mat.system.settings.config.getInt("streamee.max-into-parallelism")
           source
             .map(spawnRespondee[Out, Out2](timeout, mat))
             .alsoTo {
@@ -100,15 +106,22 @@ package object streamee {
       * @param processSink [[ProcessSink]] to emit into
       * @param timeout maximum duration for the running process to respond; must be positive!
       * @tparam Out2 response type of the given [[ProcessSink]]
+      * @return `FlowWithContext` emitting responses of the given [[ProcessSink]]
       */
-    def into[Out2](processSink: ProcessSink[Out, Out2],
-                   timeout: FiniteDuration): FlowWithContext[In, CtxIn, Out2, CtxOut, Future[M]] = {
-      require(timeout > Duration.Zero, s"timeout must be > 0, but was $timeout!")
+    def into[Out2](
+        processSink: ProcessSink[Out, Out2],
+        timeout: FiniteDuration
+    ): FlowWithContext[In, CtxIn, Out2, CtxOut, Future[M]] = {
+      require(
+        timeout > Duration.Zero,
+        s"timeout must be > 0, but was $timeout!"
+      )
 
       FlowWithContext.fromTuples(
         Flow
           .setup { (mat, _) => // We need the `ActorMaterializer` to get its `system`!
-            val parallelism = mat.system.settings.config.getInt("streamee.max-into-parallelism")
+            val parallelism = mat.system.settings.config
+              .getInt("streamee.max-into-parallelism")
             flowWithContext
               .map(spawnRespondee[Out, Out2](timeout, mat))
               .via(Flow.apply.alsoTo {
@@ -130,9 +143,15 @@ package object streamee {
       * @param g transform the emitted element
       * @tparam A target type of the transformation of the element pushed to the context
       * @tparam B target type of the transformation of the element
+      * @return `FlowWithContext` propagating its transformed input elements along with the context and emitting transformed input elements
       */
-    def push[A, B](f: Out => A, g: Out => B): FlowWithContext[In, CtxIn, B, (A, CtxOut), Any] =
-      flowWithContext.via(Flow.apply.map { case (out, ctxOut) => (g(out), (f(out), ctxOut)) })
+    def push[A, B](
+        f: Out => A,
+        g: Out => B
+    ): FlowWithContext[In, CtxIn, B, (A, CtxOut), Any] =
+      flowWithContext.via(Flow.apply.map {
+        case (out, ctxOut) => (g(out), (f(out), ctxOut))
+      })
 
     /**
       * Push the emitted element to the propagated context.
@@ -152,9 +171,13 @@ package object streamee {
     /**
       * Pop a formerly pushed and potentially transformed element from the propagated context and
       * pair it up with the emitted element.
+      *
+      * @return `FlowWithContext` propagating the former context only and emitting the propagated transformed former input elements along with its actual input elements
       */
     def pop: FlowWithContext[In, CtxIn, (A, Out), CtxOut, Any] =
-      flowWithContext.via(Flow.apply.map { case (out, (a, ctxOut)) => ((a, out), ctxOut) })
+      flowWithContext.via(Flow.apply.map {
+        case (out, (a, ctxOut)) => ((a, out), ctxOut)
+      })
   }
 
   /**
@@ -174,8 +197,13 @@ package object streamee {
                  per: FiniteDuration,
                  maximumBurst: Int,
                  mode: ThrottleMode): flowWithContext.Repr[Out, CtxOut] =
-      flowWithContext.via(Flow.apply.throttle(elements, per, maximumBurst, mode))
+      flowWithContext.via(
+        Flow.apply.throttle(elements, per, maximumBurst, mode)
+      )
   }
+
+  private[streamee] def toActorMaterializer(mat: Materializer) =
+    mat.asInstanceOf[ActorMaterializer]
 
   private def spawnRespondee[Out, Out2](timeout: FiniteDuration, mat: Materializer)(out: Out) = {
     val (respondee2, out2) = Respondee.spawn[Out2](timeout)(mat)


### PR DESCRIPTION
The idea is to always hook processors into coordinated shutdown. Why always? Well, why not? It probably cannot hurt, because of the way coordinated shutdown proceeds after the phase timeout even if the registered tasks haven't completed. And hooking up the processors is probably what everybody wants.

`FrontProcessor`s by default get registered in the phase `PhaseServiceRequestsDone`, `IntoableProcessor`s in the later phase `PhaseServiceStop`. Of course the default values can be overridden.