### PR TITLE
Make Process top-level and introduce Step

### DIFF
--- a/streamee-demo/src/main/scala/io/moia/streamee/demo/WordShuffler.scala
+++ b/streamee-demo/src/main/scala/io/moia/streamee/demo/WordShuffler.scala
@@ -19,7 +19,7 @@ package io.moia.streamee.demo
 import akka.actor.typed.{ ActorRef, Behavior }
 import akka.actor.typed.scaladsl.Behaviors
 import akka.stream.Materializer
-import io.moia.streamee.{ IntoableProcessor, Process, ProcessSinkRef }
+import io.moia.streamee.{ IntoableProcessor, Process, ProcessSinkRef, Respondee, Step }
 import org.slf4j.LoggerFactory
 import scala.annotation.tailrec
 import scala.util.Random
@@ -29,20 +29,20 @@ object WordShuffler {
   final case class ShuffleWord(word: String)
   final case class WordShuffled(word: String)
 
-  def apply(): Process[ShuffleWord, WordShuffled, WordShuffled] =
-    Process[ShuffleWord, WordShuffled]()
+  def apply(): Process[ShuffleWord, WordShuffled] =
+    Step[ShuffleWord, Respondee[WordShuffled]]()
       .via(shuffleWordToString)
       .via(shuffle)
       .via(stringToWordShuffled)
 
-  def shuffleWordToString: Process[ShuffleWord, String, WordShuffled] =
-    Process[ShuffleWord, WordShuffled]().map(_.word)
+  def shuffleWordToString[Ctx]: Step[ShuffleWord, String, Ctx] =
+    Step[ShuffleWord, Ctx]().map(_.word)
 
-  def shuffle: Process[String, String, WordShuffled] =
-    Process[String, WordShuffled]().map(shuffleWord)
+  def shuffle[Ctx]: Step[String, String, Ctx] =
+    Step[String, Ctx]().map(shuffleWord)
 
-  def stringToWordShuffled: Process[String, WordShuffled, WordShuffled] =
-    Process().map(WordShuffled)
+  def stringToWordShuffled[Ctx]: Step[String, WordShuffled, Ctx] =
+    Step[String, Ctx]().map(WordShuffled)
 
   private def shuffleWord(word: String) = {
     @tailrec def loop(word: String, acc: String = ""): String =

--- a/streamee/src/main/scala/io/moia/streamee/FrontProcessor.scala
+++ b/streamee/src/main/scala/io/moia/streamee/FrontProcessor.scala
@@ -70,7 +70,7 @@ object FrontProcessor {
     * @return [[FrontProcessor]]
     */
   def apply[Req, Res](
-      process: Process[Req, Res, Res],
+      process: Process[Req, Res],
       timeout: FiniteDuration,
       name: String,
       bufferSize: Int = 1,
@@ -84,7 +84,7 @@ object FrontProcessor {
   * responding to the [[Respondee]].
   */
 final class FrontProcessor[Req, Res] private (
-    process: Process[Req, Res, Res],
+    process: Process[Req, Res],
     timeout: FiniteDuration,
     name: String,
     bufferSize: Int,

--- a/streamee/src/main/scala/io/moia/streamee/IntoableProcessor.scala
+++ b/streamee/src/main/scala/io/moia/streamee/IntoableProcessor.scala
@@ -41,7 +41,7 @@ object IntoableProcessor {
     * @return [[IntoableProcessor]]
     */
   def apply[Req, Res](
-      process: Process[Req, Res, Res],
+      process: Process[Req, Res],
       name: String,
       bufferSize: Int = 1,
       phase: String = CoordinatedShutdown.PhaseServiceStop
@@ -54,7 +54,7 @@ object IntoableProcessor {
   * Notice that shutting down might result in dropping (losing) `bufferSize` number of requsts!
   */
 final class IntoableProcessor[Req, Res] private (
-    process: Process[Req, Res, Res],
+    process: Process[Req, Res],
     name: String,
     bufferSize: Int,
     phase: String

--- a/streamee/src/main/scala/io/moia/streamee/Step.scala
+++ b/streamee/src/main/scala/io/moia/streamee/Step.scala
@@ -18,16 +18,15 @@ package io.moia.streamee
 
 import akka.stream.scaladsl.FlowWithContext
 
-object Process {
+object Step {
 
   /**
-    * Factory for an empty [[Process]]. Convenient shortcut for
-    * `FlowWithContext[Req, Respondee[Res]]`.
+    * Create an empty [[Step]] instance which can be used as an initial process step.
     *
-    * @tparam Req request type
-    * @tparam Res response type
-    * @return empty [[Process]]
+    * @tparam In input type of the initial process step
+    * @tparam Ctx context type of the initial process step
+    * @return Empty [[Step]]
     */
-  def apply[Req, Res](): Process[Req, Req, Res] =
-    FlowWithContext[Req, Respondee[Res]]
+  def apply[In, Ctx](): Step[In, In, Ctx] =
+    FlowWithContext[In, Ctx]
 }


### PR DESCRIPTION
The `Process` type alias now is only used for top-level processes, i.e. flows from `Req` to `Res`. This means, that the context is now tied down to `Respondee[Res]`, whereas before `Out` or more specifically `Respondee[Out]` was free to deviate from `Res`.

To define process steps, the `Step` type alias is introduced, which comes with a "free" context. The difference between the old `Process` and the `Step` is that the latter does not have a context tied down to `Respondee[Res]`. This allows for defining process steps which are generic in their context and hence can be easily reused in different places which require different context types – see the updated `WordShuffler` and `TextShuffler` demos.