### PR TITLE
Bump to Scala 2.13.1 and Akka 2.6.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,8 +21,7 @@ lazy val `streamee` =
       libraryDependencies ++= Seq(
         library.akkaHttp,
         library.akkaStreamTyped,
-        library.log4jApi,
-        library.log4jApiScala,
+        library.slf4jApi,
         library.akkaActorTestkitTyped % Test,
         library.akkaHttpTestkit       % Test,
         library.akkaStreamTestkit     % Test,
@@ -45,7 +44,6 @@ lazy val `streamee-demo` =
         library.akkaSlf4j,
         library.circeGeneric,
         library.disruptor,
-        library.log4jApiScala,
         library.log4jCore,
         library.log4jSlf4j,
         library.pureConfig,
@@ -60,17 +58,17 @@ lazy val `streamee-demo` =
 lazy val library =
   new {
     object Version {
-      val akka           = "2.6.0-RC2"
+      val akka           = "2.6.0"
       val akkaHttp       = "10.1.10"
       val akkaHttpJson   = "1.29.1"
       val akkaLog4j      = "1.6.1"
       val circe          = "0.12.3"
       val disruptor      = "3.4.2"
       val log4j          = "2.12.1"
-      val log4jApiScala  = "11.0"
       val pureConfig     = "0.12.1"
       val scalaCheck     = "1.14.2"
       val scalaTest      = "3.0.8"
+      val slf4j          = "1.7.29"
     }
     val akkaActorTestkitTyped    = "com.typesafe.akka"        %% "akka-actor-testkit-typed"    % Version.akka
     val akkaClusterShardingTyped = "com.typesafe.akka"        %% "akka-cluster-sharding-typed" % Version.akka
@@ -82,13 +80,12 @@ lazy val library =
     val akkaStreamTyped          = "com.typesafe.akka"        %% "akka-stream-typed"           % Version.akka
     val circeGeneric             = "io.circe"                 %% "circe-generic"               % Version.circe
     val disruptor                = "com.lmax"                 %  "disruptor"                   % Version.disruptor
-    val log4jApi                 = "org.apache.logging.log4j" %  "log4j-api"                   % Version.log4j
-    val log4jApiScala            = "org.apache.logging.log4j" %% "log4j-api-scala"             % Version.log4jApiScala
     val log4jCore                = "org.apache.logging.log4j" %  "log4j-core"                  % Version.log4j
     val log4jSlf4j               = "org.apache.logging.log4j" %  "log4j-slf4j-impl"            % Version.log4j
     val pureConfig               = "com.github.pureconfig"    %% "pureconfig"                  % Version.pureConfig
     val scalaCheck               = "org.scalacheck"           %% "scalacheck"                  % Version.scalaCheck
     val scalaTest                = "org.scalatest"            %% "scalatest"                   % Version.scalaTest
+    val slf4jApi                 = "org.slf4j"                %  "slf4j-api"                   % Version.slf4j
   }
 
 // *****************************************************************************
@@ -103,7 +100,7 @@ lazy val settings =
 
 lazy val commonSettings =
   Seq(
-    scalaVersion := "2.12.10",
+    scalaVersion := "2.13.1",
     organization := "io.moia",
     organizationName := "MOIA GmbH",
     startYear := Some(2018),
@@ -114,8 +111,6 @@ lazy val commonSettings =
       "-language:_",
       "-target:jvm-1.8",
       "-encoding", "UTF-8",
-      "-Ypartial-unification",
-      "-Ywarn-unused-import"
     ),
     Compile / unmanagedSourceDirectories := Seq((Compile / scalaSource).value),
     Test / unmanagedSourceDirectories := Seq((Test / scalaSource).value),
@@ -129,7 +124,7 @@ lazy val scalafmtSettings =
 lazy val sonatypeSettings = {
   import xerial.sbt.Sonatype._
   Seq(
-    publishTo := sonatypePublishTo.value,
+    publishTo := sonatypePublishToBundle.value,
     sonatypeProfileName := organization.value,
     publishMavenStyle := true,
     sonatypeProjectHosting := Some(GitHubHosting("moia-dev", "streamee", "support@moia.io")),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("com.dwijnand"      % "sbt-dynver"   % "4.0.0")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt" % "2.2.1")
 addSbtPlugin("com.jsuereth"      % "sbt-pgp"      % "2.0.0")
-addSbtPlugin("de.heikoseeberger" % "sbt-header"   % "5.2.0")
+addSbtPlugin("de.heikoseeberger" % "sbt-header"   % "5.3.0")
 addSbtPlugin("io.spray"          % "sbt-revolver" % "0.9.1")
-addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype" % "2.3")
+addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype" % "3.8")

--- a/streamee/src/main/scala/io/moia/streamee/IntoableProcessor.scala
+++ b/streamee/src/main/scala/io/moia/streamee/IntoableProcessor.scala
@@ -20,7 +20,7 @@ import akka.stream.{ ActorAttributes, Attributes, KillSwitches, Materializer, Su
 import akka.stream.scaladsl.{ Keep, MergeHub, Sink, StreamRefs }
 import akka.Done
 import akka.actor.CoordinatedShutdown
-import org.apache.logging.log4j.scala.Logging
+import org.slf4j.LoggerFactory
 import scala.concurrent.Future
 
 object IntoableProcessor {
@@ -58,9 +58,10 @@ final class IntoableProcessor[Req, Res] private (
     name: String,
     bufferSize: Int,
     phase: String
-)(implicit mat: Materializer)
-    extends Logging {
+)(implicit mat: Materializer) {
   require(bufferSize > 0, s"bufferSize for processor $name must be > 0, but was $bufferSize!")
+
+  private val logger = LoggerFactory.getLogger(getClass)
 
   private val (_sink, switch, _done) =
     MergeHub
@@ -102,7 +103,7 @@ final class IntoableProcessor[Req, Res] private (
     * accepted. To watch shutdown completion use [[whenDone]].
     */
   def shutdown(): Unit = {
-    logger.warn(s"Shutdown for processor $name requested!")
+    if (logger.isWarnEnabled) logger.warn(s"Shutdown for processor $name requested!")
     switch.shutdown()
   }
 
@@ -116,7 +117,7 @@ final class IntoableProcessor[Req, Res] private (
     _done
 
   private def resume(cause: Throwable) = {
-    logger.error(s"Processor $name failed and resumes", cause)
+    if (logger.isErrorEnabled) logger.error(s"Processor $name failed and resumes", cause)
     Supervision.Resume
   }
 }

--- a/streamee/src/main/scala/io/moia/streamee/Process.scala
+++ b/streamee/src/main/scala/io/moia/streamee/Process.scala
@@ -17,9 +17,8 @@
 package io.moia.streamee
 
 import akka.stream.scaladsl.FlowWithContext
-import org.apache.logging.log4j.scala.Logging
 
-object Process extends Logging {
+object Process {
 
   /**
     * Factory for an empty [[Process]]. Convenient shortcut for


### PR DESCRIPTION
Also moved from Log4j Scala API to SLF4J, because the former was not yet available for Scala 2.13 and Akka Typed also is using SLf4J.