### PR TITLE
Use apply instead of startProcess and startStep

### DIFF
--- a/streamee-demo/src/main/scala/io/moia/streamee/demo/TextShuffler.scala
+++ b/streamee-demo/src/main/scala/io/moia/streamee/demo/TextShuffler.scala
@@ -27,9 +27,7 @@ import io.moia.streamee.{
   ProcessSink,
   ProcessSinkRef,
   SourceExt,
-  Step,
-  startProcess,
-  startStep
+  Step
 }
 import io.moia.streamee.demo.WordShuffler.{ ShuffleWord, WordShuffled }
 import scala.collection.immutable.Seq
@@ -64,14 +62,14 @@ object TextShuffler {
         Await.result(wordShufflerSinkRef().map(_.sink), wordShufflerAskTimeout) // Hopefully we can get rid of blocking soon: https://github.com/akka/akka/issues/25934
       }
 
-    startProcess[ShuffleText, TextShuffled]
+    Process[ShuffleText, TextShuffled]
       .via(delayRequest(delay))
       .via(keepSplitShuffle(wordShufflerSink, wordShufflerProcessorTimeout))
       .via(concat)
   }
 
   def delayRequest[Ctx](of: FiniteDuration): Step[ShuffleText, ShuffleText, Ctx] =
-    startStep[ShuffleText, Ctx]
+    Step[ShuffleText, Ctx]
       .delay(of, DelayOverflowStrategy.backpressure)
       .withAttributes(Attributes.inputBuffer(1, 1))
 
@@ -79,7 +77,7 @@ object TextShuffler {
       wordShufflerSink: ProcessSink[WordShuffler.ShuffleWord, WordShuffler.WordShuffled],
       wordShufflerProcessorTimeout: FiniteDuration
   )(implicit mat: Materializer): Step[ShuffleText, (String, Seq[String]), Ctx] =
-    startStep[ShuffleText, Ctx]
+    Step[ShuffleText, Ctx]
       .map(_.text)
       .push // push the original text
       .map(_.split(" ").toList)
@@ -90,7 +88,7 @@ object TextShuffler {
       wordShufflerSink: ProcessSink[WordShuffler.ShuffleWord, WordShuffler.WordShuffled],
       wordShufflerProcessorTimeout: FiniteDuration
   )(implicit mat: Materializer): Step[Seq[String], Seq[String], Ctx] =
-    startStep[Seq[String], Ctx]
+    Step[Seq[String], Ctx]
       .mapAsync(1) { words =>
         Source(words)
           .map(WordShuffler.ShuffleWord)
@@ -100,7 +98,7 @@ object TextShuffler {
       .map(_.map(_.word))
 
   def concat[Ctx]: Step[(String, Seq[String]), TextShuffled, Ctx] =
-    startStep[(String, Seq[String]), Ctx].map {
+    Step[(String, Seq[String]), Ctx].map {
       case (originalText, shuffledWords) => TextShuffled(originalText, shuffledWords.mkString(" "))
     }
 }

--- a/streamee-demo/src/main/scala/io/moia/streamee/demo/WordShuffler.scala
+++ b/streamee-demo/src/main/scala/io/moia/streamee/demo/WordShuffler.scala
@@ -19,14 +19,7 @@ package io.moia.streamee.demo
 import akka.actor.typed.{ ActorRef, Behavior }
 import akka.actor.typed.scaladsl.Behaviors
 import akka.stream.Materializer
-import io.moia.streamee.{
-  IntoableProcessor,
-  Process,
-  ProcessSinkRef,
-  Step,
-  startProcess,
-  startStep
-}
+import io.moia.streamee.{ IntoableProcessor, Process, ProcessSinkRef, Step }
 import org.slf4j.LoggerFactory
 import scala.annotation.tailrec
 import scala.util.Random
@@ -37,19 +30,19 @@ object WordShuffler {
   final case class WordShuffled(word: String)
 
   def apply(): Process[ShuffleWord, WordShuffled] =
-    startProcess[ShuffleWord, WordShuffled]
+    Process[ShuffleWord, WordShuffled]
       .via(shuffleWordToString)
       .via(shuffle)
       .via(stringToWordShuffled)
 
   def shuffleWordToString[Ctx]: Step[ShuffleWord, String, Ctx] =
-    startStep[ShuffleWord, Ctx].map(_.word)
+    Step[ShuffleWord, Ctx].map(_.word)
 
   def shuffle[Ctx]: Step[String, String, Ctx] =
-    startStep[String, Ctx].map(shuffleWord)
+    Step[String, Ctx].map(shuffleWord)
 
   def stringToWordShuffled[Ctx]: Step[String, WordShuffled, Ctx] =
-    startStep[String, Ctx].map(WordShuffled)
+    Step[String, Ctx].map(WordShuffled)
 
   private def shuffleWord(word: String) = {
     @tailrec def loop(word: String, acc: String = ""): String =

--- a/streamee/src/main/scala/io/moia/streamee/Process.scala
+++ b/streamee/src/main/scala/io/moia/streamee/Process.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 MOIA GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.moia.streamee
+
+object Process {
+
+  /**
+    * Create an empty initial process [[Step]], i.e. one where the context is a [[Respondee]].
+    *
+    * @tparam Req request type
+    * @tparam Res response type
+    * @return empty initial process [[Step]]
+    */
+  def apply[Req, Res]: Step[Req, Req, Respondee[Res]] =
+    Step[Req, Respondee[Res]]
+}

--- a/streamee/src/main/scala/io/moia/streamee/Step.scala
+++ b/streamee/src/main/scala/io/moia/streamee/Step.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 MOIA GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.moia.streamee
+
+import akka.stream.scaladsl.FlowWithContext
+
+object Step {
+
+  /**
+    * Create an empty initial [[Step]].
+    *
+    * @tparam In input type of the initial step
+    * @tparam Ctx context type of the initial step
+    * @return empty initial [[Step]]
+    */
+  def apply[In, Ctx]: Step[In, In, Ctx] =
+    FlowWithContext[In, Ctx]
+}

--- a/streamee/src/main/scala/io/moia/streamee/package.scala
+++ b/streamee/src/main/scala/io/moia/streamee/package.scala
@@ -30,7 +30,7 @@ package object streamee {
     * [[Respondee]] for the response. Can be used locally or remotely because the propagated
     * [[Respondee]] is location transparent.
     *
-    * Use [[startProcess]] to create an empty initial process [[Step]], i.e. one where the context
+    * Use [[Process]] to create an empty initial process [[Step]], i.e. one where the context
     * is a [[Respondee]].
     */
   type Process[-Req, Res] = Step[Req, Res, Respondee[Res]]
@@ -40,7 +40,7 @@ package object streamee {
     * order to compose [[Step]]s into a [[Process]] a [[Respondee]] must at least be a part of
     * the context.
     *
-    * Use [[startStep]] to create an empty initial [[Step]].
+    * Use [[Step]] to create an empty initial [[Step]].
     */
   type Step[-In, +Out, Ctx] = FlowWithContext[In, Ctx, Out, Ctx, Any]
 
@@ -226,7 +226,7 @@ package object streamee {
       require(parallelism > 0, s"parallelism must be > 0, but was $parallelism!")
 
       FrontProcessor(
-        startProcess[Req, Res].into(sink, timeout, parallelism),
+        Process[Req, Res].into(sink, timeout, parallelism),
         timeout,
         name,
         bufferSize,
@@ -274,26 +274,6 @@ package object streamee {
       .mapAsync(parallelism)(_._3.future)
 
   /**
-    * Create an empty initial process [[Step]], i.e. one where the context is a [[Respondee]].
-    *
-    * @tparam Req request type
-    * @tparam Res response type
-    * @return empty initial process [[Step]]
-    */
-  def startProcess[Req, Res]: Step[Req, Req, Respondee[Res]] =
-    startStep[Req, Respondee[Res]]
-
-  /**
-    * Create an empty initial [[Step]].
-    *
-    * @tparam In input type of the initial step
-    * @tparam Ctx context type of the initial step
-    * @return empty initial [[Step]]
-    */
-  def startStep[In, Ctx]: Step[In, In, Ctx] =
-    FlowWithContext[In, Ctx]
-
-  /**
     * Wraps the given [[Step]] in one emitting its input together with its output (as a `Tuple2`).
     *
     * Notice that thanks to type inference there should be no special requirements regarding the
@@ -302,7 +282,7 @@ package object streamee {
     *
     *{{{
     *def length[Ctx]: Step[String, Int, Ctx] =
-    *  startStep[String, Ctx].map(_.length)
+    *  Step[String, Ctx].map(_.length)
     *
     *val process: Process[String, (String, Int)] =
     *  zipWithIn(lenght) // No need to give type args to length!
@@ -315,7 +295,7 @@ package object streamee {
     * @return [[Step]] emitting the input of the wrapped one together with its ouput (as a `Tuple2`)
     */
   def zipWithIn[In, Out, Ctx](step: Step[In, Out, (In, Ctx)]): Step[In, (In, Out), Ctx] =
-    startStep[In, Ctx].push.via(step).pop
+    Step[In, Ctx].push.via(step).pop
 
   private def spawnRespondee[Out, Out2](timeout: FiniteDuration, mat: Materializer)(out: Out) = {
     val (respondee2, out2) = Respondee.spawn[Out2](timeout)(mat)

--- a/streamee/src/test/scala/io/moia/streamee/FrontProcessorTests.scala
+++ b/streamee/src/test/scala/io/moia/streamee/FrontProcessorTests.scala
@@ -36,7 +36,7 @@ final class FrontProcessorTests
     "throw an IllegalArgumentException for timeout <= 0" in {
       forAll(TestData.nonPosDuration) { timeout =>
         an[IllegalArgumentException] shouldBe thrownBy {
-          FrontProcessor(startProcess[Int, Int], timeout, "name")
+          FrontProcessor(Process[Int, Int], timeout, "name")
         }
       }
     }
@@ -44,7 +44,7 @@ final class FrontProcessorTests
     "throw an IllegalArgumentException for bufferSize <= 0" in {
       forAll(Gen.choose(Int.MinValue, 0)) { bufferSize =>
         an[IllegalArgumentException] shouldBe thrownBy {
-          FrontProcessor(startProcess[Int, Int], 1.second, "name", bufferSize)
+          FrontProcessor(Process[Int, Int], 1.second, "name", bufferSize)
         }
       }
     }
@@ -52,7 +52,7 @@ final class FrontProcessorTests
 
   "Calling offer" should {
     "eventually succeed" in {
-      val process   = startProcess[String, Int].map(_.length)
+      val process   = Process[String, Int].map(_.length)
       val processor = FrontProcessor(process, 1.second, "name")
       processor
         .offer("abc")
@@ -61,7 +61,7 @@ final class FrontProcessorTests
 
     "fail after the given timeout" in {
       val timeout   = 100.milliseconds
-      val process   = startProcess[String, String].delay(1.second)
+      val process   = Process[String, String].delay(1.second)
       val processor = FrontProcessor(process, timeout, "name")
       processor
         .offer("abc")
@@ -70,7 +70,7 @@ final class FrontProcessorTests
     }
 
     "resume on failure" in {
-      val process   = startProcess[(Int, Int), Int].map { case (n, m) => n / m }
+      val process   = Process[(Int, Int), Int].map { case (n, m) => n / m }
       val processor = FrontProcessor(process, 1.second, "name")
       processor
         .offer((4, 0))
@@ -82,7 +82,7 @@ final class FrontProcessorTests
     }
 
     "process already offered requests on shutdown" in {
-      val process   = startProcess[String, String].delay(100.milliseconds)
+      val process   = Process[String, String].delay(100.milliseconds)
       val processor = FrontProcessor(process, 1.second, "name")
       val response1 = processor.offer("abc")
       processor.shutdown()
@@ -97,7 +97,7 @@ final class FrontProcessorTests
 
   "Calling shutdown" should {
     "complete whenDone" in {
-      val processor = FrontProcessor(startProcess[Int, Int], 1.second, "name")
+      val processor = FrontProcessor(Process[Int, Int], 1.second, "name")
       val done      = processor.whenDone
       processor.shutdown()
       for {
@@ -112,7 +112,7 @@ final class FrontProcessorTests
       val testSystem = ActorSystem()
       val testMat    = Materializer(testSystem)
       val processor =
-        FrontProcessor(startProcess[Int, Int], 1.second, "name")(
+        FrontProcessor(Process[Int, Int], 1.second, "name")(
           testMat,
           testSystem.dispatcher
         )

--- a/streamee/src/test/scala/io/moia/streamee/StreameeTests.scala
+++ b/streamee/src/test/scala/io/moia/streamee/StreameeTests.scala
@@ -159,7 +159,7 @@ final class StreameeTests
   "Calling push and pop" should {
     "first push each elements to the propagated context and then pop it" in {
       val process =
-        startProcess[String, (String, Int)]
+        Process[String, (String, Int)]
           .map(_.toUpperCase)
           .push
           .map(_.length)
@@ -181,7 +181,7 @@ final class StreameeTests
 
     "first push and transform each elements to the propagated context and then pop and transform it" in {
       val process =
-        startProcess[String, (String, Int)]
+        Process[String, (String, Int)]
           .push(_.toUpperCase, _ * 2)
           .map(_.length)
           .pop
@@ -203,7 +203,7 @@ final class StreameeTests
 
   "Calling asFrontProcessor" should {
     "convert an IntoableSink into a FrontProcessor" in {
-      val process           = startProcess[String, Int].map(_.length)
+      val process           = Process[String, Int].map(_.length)
       val intoableProcessor = IntoableProcessor(process, "name")
       val frontProcessor    = intoableProcessor.sink.asFrontProcessor(1.second, 42, "name")
       frontProcessor
@@ -214,7 +214,7 @@ final class StreameeTests
 
   "Calling zipWithIn" should {
     "wrap the given step in one emitting its input together with its output" in {
-      def length[Ctx]                                = startStep[String, Ctx].map(_.length)
+      def length[Ctx]                                = Step[String, Ctx].map(_.length)
       val step: Step[String, (String, Int), NotUsed] = zipWithIn(length)
       val test                                       = "test"
       SourceWithContext


### PR DESCRIPTION
I think I now agree with @aquamatthias that we should rather use `Process.apply` and `Step.apply` instead of `startProcess` and `startStep`.

Of course `Process.apply` does not create a `Process` but a `Step` instead, but on the one hand this is well documented (ScalaDoc and return type) and on the other hand I think it reads quite intuitively when used in a typical context:

``` scala
def apply(...): Process[ShuffleText, TextShuffled] = {
  ...

  Process[ShuffleText, TextShuffled]
    .via(delayRequest(delay))
    .via(keepSplitShuffle(wordShufflerSink, wordShufflerProcessorTimeout))
    .via(concat)
}
```

Should we merge this PR? I think so ;-)