### PR TITLE
Tap errors with errorTo

### DIFF
--- a/streamee/src/main/scala/Scratch.scala
+++ b/streamee/src/main/scala/Scratch.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018 MOIA GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import akka.actor.ActorSystem
+import akka.stream.scaladsl.{ BroadcastHub, Flow, Keep, MergeHub, Sink, Source }
+import akka.NotUsed
+import scala.concurrent.duration.DurationInt
+
+object Scratch {
+
+  sealed trait Error
+  final object Error {
+    final case class OddNumber(n: Int)         extends Error
+    final case class TooLargeNumber(n: Int)    extends Error
+    final case class WayTooLargeNumber(n: Int) extends Error
+  }
+
+  implicit final class FlowExt[In, Out, E, Mat](val flow: Flow[In, Either[E, Out], Mat])
+      extends AnyVal {
+    def unwrap(errors: Sink[Either[E, Out], Any]): Flow[In, Out, Mat] =
+      flow
+        .alsoTo(
+          Flow[Either[E, Out]]
+            .filter(_.isLeft)
+            .to(errors)
+        )
+        .collect { case Right(n) => n }
+  }
+
+  def main(args: Array[String]): Unit = {
+    implicit val system: ActorSystem = ActorSystem()
+
+    val (errorSink, errorSource) =
+      MergeHub
+        .source[Either[Error, Int]]
+        .toMat(BroadcastHub.sink[Either[Error, Int]])(Keep.both)
+        .run()
+
+    val process: Flow[Int, Either[Error, Int], Any] =
+      Flow[Int]
+        .map(n => if (n % 2 != 0) Left(Error.OddNumber(n)) else Right(n))
+        .unwrap(errorSink)
+        .map(n => if (n > 10) Left(Error.TooLargeNumber(n)) else Right(n))
+        .unwrap(errorSink)
+        .map(n => if (n > 20) Left(Error.WayTooLargeNumber(n)) else Right(n))
+        .merge(errorSource, eagerComplete = true)
+
+    val done =
+      Source(22.to(6).by(-1))
+        .zipWith(Source.tick(0.millis, 250.millis, NotUsed)) { case (n, _) => n }
+        .via(process)
+        .runForeach(println)
+
+//    StdIn.readLine("Hit ENTER to continue ...")
+//    switch.shutdown()
+
+    import system.dispatcher
+    done.onComplete { result =>
+      println(s"terminating ...: $result")
+      system.terminate()
+    }
+    system.whenTerminated.onComplete { result =>
+      println(s"terminated: $result")
+    }
+  }
+}


### PR DESCRIPTION
WIP, don't merge!

@aquamatthias, please take a look:

This is an alternative to sequencial error handling (`mapVia`, `flatMapVia`, etc.). The idea is to unwrap `Either` and push the "right" contents downsteam as usual and the "left" errors also to a sink which collects all errors into a source which is merged at the end of the process to combine "right" and "left" again.

Pro:
- Only one single extension method for `Flow(WithContext)` needed: `unwrap` (or better  name)
- Parallel error processing means that errors can overtake potential slow "right" downstream

Con:
- We must use `eagerComplete = true` for merging back the errors which means we might loose errors on shutdown (unlikely to loose a lot, because the error path should be fast)
- One additional method call (`unwrap`) – but this might even be easier to understand than the "magic" of `mapVia` and co.
