### PR TITLE
[streamee4] Use scala 2.13 with cross compile

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ lazy val `streamee` =
         library.akkaHttp,
         library.akkaStreamTyped,
         library.log4jApi,
-        library.scalaLogging,
+        library.slf4jApi,
         library.akkaActorTestkitTyped % Test,
         library.akkaHttpTestkit       % Test,
         library.akkaStreamTestkit     % Test,
@@ -48,10 +48,10 @@ lazy val `streamee-demo` =
         library.akkaSlf4j,
         library.circeGeneric,
         library.disruptor,
-        library.scalaLogging,
         library.log4jCore,
         library.log4jSlf4j,
-        library.pureConfig
+        library.pureConfig,
+        library.slf4jApi
       ),
       publishArtifact := false
     )
@@ -71,11 +71,10 @@ lazy val library =
       val circe          = "0.12.3"
       val disruptor      = "3.4.2"
       val log4j          = "2.13.0"
-      val log4jApiScala  = "11.0"
       val pureConfig     = "0.12.2"
       val scalaCheck     = "1.14.3"
-      val scalaLogging   = "3.9.2"
       val utest          = "0.7.2"
+      val slf4j          = "1.7.30"
     }
     val akkaActorTestkitTyped          = "com.typesafe.akka"             %% "akka-actor-testkit-typed"          % Version.akka
     val akkaClusterShardingTyped       = "com.typesafe.akka"             %% "akka-cluster-sharding-typed"       % Version.akka
@@ -90,12 +89,12 @@ lazy val library =
     val circeGeneric                   = "io.circe"                      %% "circe-generic"                     % Version.circe
     val disruptor                      = "com.lmax"                      %  "disruptor"                         % Version.disruptor
     val log4jApi                       = "org.apache.logging.log4j"      %  "log4j-api"                         % Version.log4j
-    val scalaLogging                   = "com.typesafe.scala-logging"    %% "scala-logging"                     % Version.scalaLogging
     val log4jCore                      = "org.apache.logging.log4j"      %  "log4j-core"                        % Version.log4j
     val log4jSlf4j                     = "org.apache.logging.log4j"      %  "log4j-slf4j-impl"                  % Version.log4j
     val pureConfig                     = "com.github.pureconfig"         %% "pureconfig"                        % Version.pureConfig
     val scalaCheck                     = "org.scalacheck"                %% "scalacheck"                        % Version.scalaCheck
     val utest                          = "com.lihaoyi"                   %% "utest"                             % Version.utest
+    val slf4jApi                       = "org.slf4j"                     %  "slf4j-api"                         % Version.slf4j
   }
 
 // *****************************************************************************

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ lazy val `streamee` =
         library.akkaHttp,
         library.akkaStreamTyped,
         library.log4jApi,
-        library.log4jApiScala,
+        library.scalaLogging,
         library.akkaActorTestkitTyped % Test,
         library.akkaHttpTestkit       % Test,
         library.akkaStreamTestkit     % Test,
@@ -42,14 +42,13 @@ lazy val `streamee-demo` =
       Compile / packageSrc / publishArtifact := false,
       libraryDependencies ++= Seq(
         library.akkaClusterShardingTyped,
-        library.akkaDiscoveryDns,
         library.akkaHttpCirce,
         library.akkaManagementClusterBootstrap,
         library.akkaManagementClusterHttp,
         library.akkaSlf4j,
         library.circeGeneric,
         library.disruptor,
-        library.log4jApiScala,
+        library.scalaLogging,
         library.log4jCore,
         library.log4jSlf4j,
         library.pureConfig
@@ -64,22 +63,22 @@ lazy val `streamee-demo` =
 lazy val library =
   new {
     object Version {
-      val akka           = "2.6.0"
-      val akkaHttp       = "10.1.7"
-      val akkaHttpJson   = "1.25.2"
+      val akka           = "2.6.1"
+      val akkaHttp       = "10.1.11"
+      val akkaHttpJson   = "1.30.0"
       val akkaLog4j      = "1.6.1"
-      val akkaManagement = "0.20.0"
-      val circe          = "0.11.1"
+      val akkaManagement = "1.0.5"
+      val circe          = "0.12.3"
       val disruptor      = "3.4.2"
-      val log4j          = "2.11.1"
+      val log4j          = "2.13.0"
       val log4jApiScala  = "11.0"
-      val pureConfig     = "0.10.1"
-      val scalaCheck     = "1.14.0"
-      val utest          = "0.7.1"
+      val pureConfig     = "0.12.2"
+      val scalaCheck     = "1.14.3"
+      val scalaLogging   = "3.9.2"
+      val utest          = "0.7.2"
     }
     val akkaActorTestkitTyped          = "com.typesafe.akka"             %% "akka-actor-testkit-typed"          % Version.akka
     val akkaClusterShardingTyped       = "com.typesafe.akka"             %% "akka-cluster-sharding-typed"       % Version.akka
-    val akkaDiscoveryDns               = "com.lightbend.akka.discovery"  %% "akka-discovery-dns"                % Version.akkaManagement
     val akkaHttp                       = "com.typesafe.akka"             %% "akka-http"                         % Version.akkaHttp
     val akkaHttpCirce                  = "de.heikoseeberger"             %% "akka-http-circe"                   % Version.akkaHttpJson
     val akkaHttpTestkit                = "com.typesafe.akka"             %% "akka-http-testkit"                 % Version.akkaHttp
@@ -91,7 +90,7 @@ lazy val library =
     val circeGeneric                   = "io.circe"                      %% "circe-generic"                     % Version.circe
     val disruptor                      = "com.lmax"                      %  "disruptor"                         % Version.disruptor
     val log4jApi                       = "org.apache.logging.log4j"      %  "log4j-api"                         % Version.log4j
-    val log4jApiScala                  = "org.apache.logging.log4j"      %% "log4j-api-scala"                   % Version.log4jApiScala
+    val scalaLogging                   = "com.typesafe.scala-logging"    %% "scala-logging"                     % Version.scalaLogging
     val log4jCore                      = "org.apache.logging.log4j"      %  "log4j-core"                        % Version.log4j
     val log4jSlf4j                     = "org.apache.logging.log4j"      %  "log4j-slf4j-impl"                  % Version.log4j
     val pureConfig                     = "com.github.pureconfig"         %% "pureconfig"                        % Version.pureConfig
@@ -112,7 +111,8 @@ lazy val settings =
 
 lazy val commonSettings =
   Seq(
-    scalaVersion := "2.12.8",
+    scalaVersion := "2.13.1",
+    crossScalaVersions := Seq("2.12.10", "2.13.1"),
     organization := "io.moia",
     organizationName := "MOIA GmbH",
     startYear := Some(2018),
@@ -122,9 +122,7 @@ lazy val commonSettings =
       "-deprecation",
       "-language:_",
       "-target:jvm-1.8",
-      "-encoding", "UTF-8",
-      "-Ypartial-unification",
-      "-Ywarn-unused-import"
+      "-encoding", "UTF-8"
     ),
     Compile / unmanagedSourceDirectories := Seq((Compile / scalaSource).value),
     Test / unmanagedSourceDirectories := Seq((Test / scalaSource).value),

--- a/streamee/src/main/scala/io/moia/streamee/ExpiringPromise.scala
+++ b/streamee/src/main/scala/io/moia/streamee/ExpiringPromise.scala
@@ -38,7 +38,7 @@ object ExpiringPromise {
                                                            scheduler: Scheduler): Promise[A] = {
     val result          = Promise[A]()
     val responseTimeout = after(timeout, scheduler)(Future.failed(PromiseExpired(timeout, hint)))
-    result.tryCompleteWith(responseTimeout)
+    result.completeWith(responseTimeout)
     result
   }
 }

--- a/streamee/src/main/scala/io/moia/streamee/processor/PermanentProcessor.scala
+++ b/streamee/src/main/scala/io/moia/streamee/processor/PermanentProcessor.scala
@@ -40,17 +40,17 @@ import akka.stream.{
 }
 import akka.{ Done, NotUsed }
 import io.moia.streamee.processor.Processor.{ ProcessorUnavailable, UnexpectedQueueOfferResult }
-import org.apache.logging.log4j.scala.Logging
+import com.typesafe.scalalogging.StrictLogging
 import scala.concurrent.duration.{ Duration, FiniteDuration }
 import scala.concurrent.{ ExecutionContext, Future, Promise }
 
-private object PermanentProcessor extends Logging {
+private object PermanentProcessor extends StrictLogging {
 
   final class PromisesStage[A, B, C](correlateRequest: A => C,
                                      correlateResponse: B => C,
                                      sweepCompleteResponsesInterval: FiniteDuration)
       extends GraphStage[FanInShape2[(A, Promise[B]), B, NotUsed]]
-      with Logging {
+      with StrictLogging {
 
     override val shape: FanInShape2[(A, Promise[B]), B, NotUsed] =
       new FanInShape2(Inlet[(A, Promise[B])]("PromisesStage.in0"),

--- a/streamee/src/main/scala/io/moia/streamee/processor/PermanentProcessor.scala
+++ b/streamee/src/main/scala/io/moia/streamee/processor/PermanentProcessor.scala
@@ -40,17 +40,18 @@ import akka.stream.{
 }
 import akka.{ Done, NotUsed }
 import io.moia.streamee.processor.Processor.{ ProcessorUnavailable, UnexpectedQueueOfferResult }
-import com.typesafe.scalalogging.StrictLogging
+import org.slf4j.LoggerFactory
 import scala.concurrent.duration.{ Duration, FiniteDuration }
 import scala.concurrent.{ ExecutionContext, Future, Promise }
 
-private object PermanentProcessor extends StrictLogging {
+private object PermanentProcessor {
+
+  private val logger = LoggerFactory.getLogger(getClass)
 
   final class PromisesStage[A, B, C](correlateRequest: A => C,
                                      correlateResponse: B => C,
                                      sweepCompleteResponsesInterval: FiniteDuration)
-      extends GraphStage[FanInShape2[(A, Promise[B]), B, NotUsed]]
-      with StrictLogging {
+      extends GraphStage[FanInShape2[(A, Promise[B]), B, NotUsed]] {
 
     override val shape: FanInShape2[(A, Promise[B]), B, NotUsed] =
       new FanInShape2(Inlet[(A, Promise[B])]("PromisesStage.in0"),
@@ -107,7 +108,7 @@ private object PermanentProcessor extends StrictLogging {
   }
 
   def resume(name: String)(cause: Throwable): Supervision.Directive = {
-    logger.error(s"Processor $name failed and resumes", cause)
+    if (logger.isErrorEnabled) logger.error(s"Processor $name failed and resumes", cause)
     Supervision.Resume
   }
 }

--- a/streamee/src/main/scala/io/moia/streamee/processor/Processor.scala
+++ b/streamee/src/main/scala/io/moia/streamee/processor/Processor.scala
@@ -24,14 +24,13 @@ import akka.http.scaladsl.server.Directives.complete
 import akka.http.scaladsl.server.ExceptionHandler
 import akka.stream.scaladsl.Flow
 import akka.stream.{ Materializer, QueueOfferResult }
-import com.typesafe.scalalogging.StrictLogging
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ ExecutionContext, Future }
 
 /**
   * Factories and more for [[Processor]]s.
   */
-object Processor extends StrictLogging {
+object Processor {
 
   /**
     * Signals that a [[Processor]] cannot process requests at this time. Only relevant for

--- a/streamee/src/main/scala/io/moia/streamee/processor/Processor.scala
+++ b/streamee/src/main/scala/io/moia/streamee/processor/Processor.scala
@@ -24,14 +24,14 @@ import akka.http.scaladsl.server.Directives.complete
 import akka.http.scaladsl.server.ExceptionHandler
 import akka.stream.scaladsl.Flow
 import akka.stream.{ Materializer, QueueOfferResult }
-import org.apache.logging.log4j.scala.Logging
+import com.typesafe.scalalogging.StrictLogging
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ ExecutionContext, Future }
 
 /**
   * Factories and more for [[Processor]]s.
   */
-object Processor extends Logging {
+object Processor extends StrictLogging {
 
   /**
     * Signals that a [[Processor]] cannot process requests at this time. Only relevant for


### PR DESCRIPTION
Change:
- use scala 2.13 by default
- replace log4jScala by scalalogging (there is no 2.13 version available)
- bump necessary versions to have a 2.12/2.13 equivalent versions